### PR TITLE
Fix image update type mismatch

### DIFF
--- a/app/crt/[slug]/edit/actions.ts
+++ b/app/crt/[slug]/edit/actions.ts
@@ -11,11 +11,23 @@ export async function editCRT(data: CRTSubmission, id: number) {
     assert(session)
     if (!isAdmin(session)) return false
 
+    const images = await Promise.all(data.images.map(async (image) => ({
+        description: image.name,
+        data: Buffer.from(await image.arrayBuffer())
+    })))
+    const { images: _, ...updateData } = data;
+
     const crt = await prisma.cRT.update({
         where: {
             id: id
         },
-        data: data,
+        data: {
+            ...updateData,
+            images: {
+                deleteMany: {},
+                create: images
+            }
+        },
     });
 
     return { success: true, crt };


### PR DESCRIPTION
Correctly handle image updates in `editCRT` to match Prisma's nested write expectations.

This resolves a type error by transforming `File[]` into the required Prisma `create` and `deleteMany` format for relational image updates, ensuring images are properly processed and associated with the CRT record.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b8249ee-8249-46f1-a433-e808a11e0713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2b8249ee-8249-46f1-a433-e808a11e0713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

